### PR TITLE
Prevent Garbage Collection from removing packages installed by mise-nix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
-[*]
+[*.lua]
 indent_style = space
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .DS_Store
+
+.mise-nix/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "runtime": {
+    "version": "Lua 5.1",
     "path": [
       "lib/utils.lua",
       "types.lua"

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 100
+indent_type = "Spaces"
+indent_width = 2
+
+[sort_requires]
+enabled = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Mise Nix Flake Plugin
 
-Enable flake development environments, equivalent to `nix develop`.
+Enable flake development environments, similar to `nix develop`, but in your own
+shell.
+
+Note: `shellHook` will not be loaded.
 
 ## Installation
 
@@ -9,8 +12,6 @@ To install the `nix` plugin, run:
 ```sh
 $ mise plugins install nix
 ```
-
-## Configuration
 
 In `.mise.toml`, enable the `nix` environment:
 
@@ -22,7 +23,16 @@ _.nix = true
 This will automatically load the development environment from `flake.nix`,
 equivalent to entering the shell via `nix develop`.
 
-To use a different lock-file, set the `flake_lock` option:
+## Configuration
+
+The following options are supported:
+
+| Option        | Type     | Default      | Description                        |
+| ------------- | -------- | ------------ | ---------------------------------- |
+| `flake_lock`  | `string` | `flake.lock` | Lock file to use                   |
+| `profile_dir` | `string` | `.mise-nix`  | Directory for keeping profile link |
+
+For example, to use a specific lock-file, set the `flake_lock` option:
 
 ```toml
 [env]

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -1,30 +1,14 @@
-local json = require("json")
-local strings = require("vfox.strings") ---@class Strings
-
 local utils = require("utils")
 
 ---@dictionary "ignore" | "keep"
 local VARS = {
-  -- exported
+  PATH = "ignore", -- handled in path hook
   HOME = "ignore",
   SHELL = "ignore",
   TERM = "ignore",
   TMPDIR = "ignore",
   TZ = "ignore",
 }
-
----Load environment from handle
----@param handle file*?
----@return DevEnv?
-local function get_env(handle)
-  if handle ~= nil then
-    local status, data = pcall(json.decode, handle:read("*a"))
-    handle:close()
-    return status and data or nil
-  else
-    return nil
-  end
-end
 
 function PLUGIN:MiseEnv(ctx)
   local options = ctx.options
@@ -33,73 +17,20 @@ function PLUGIN:MiseEnv(ctx)
   elseif options == true then
     options = {}
   end
+
   ---@cast options Options
-
-  if options.flake_lock == nil then
-    options.flake_lock = "flake.lock"
-  end
-
-  local project_root = utils.find_project_root("flake.nix")
-  if project_root == nil then
-    utils.log("Unable to find flake")
+  local result = utils.load_env(options)
+  if result == nil then
     return {}
-  end
-
-  local flake_file = ("%s/%s"):format(project_root, "flake.nix")
-  local lock_file = ("%s/%s"):format(project_root, options.flake_lock)
-
-  if not utils.exists(lock_file) then
-    utils.log("Lock file does not exist: %s", lock_file)
-    return {}
-  end
-
-  local hash = utils.get_hash(flake_file, lock_file)
-  if hash == nil then
-    utils.log("Unable to hash flake files")
-    return {}
-  end
-
-  local temp_dir = string.gsub(os.getenv("TMPDIR") or "/tmp", "/+$", "")
-  local filename = ("%s/mise-nix-%s"):format(temp_dir, hash)
-
-  local tag = ("%s:%s"):format(project_root, hash)
-
-  -- check if already loaded
-  if os.getenv("MISE_NIX") == tag then
-    return {}
-  end
-
-  ---@type DevEnv?
-  local env = nil
-
-  if utils.exists(filename) then
-    -- load from cache
-    env = get_env(io.open(filename))
-  end
-
-  if env == nil then
-    -- generate from nix and cache result
-    local command = ([[
-      set -o pipefail
-      nix print-dev-env \
-        --json --quiet --option warn-dirty false \
-        --reference-lock-file %q |
-        tee %q
-    ]]):format(lock_file, filename)
-    env = get_env(io.popen(command))
-
-    if env == nil then
-      utils.log("Unable to load environment")
-      return {}
-    end
   end
 
   ---@type { key: string, value: string}[]
   local exports = {
-    { key = "MISE_NIX", value = tag },
+    { key = "MISE_NIX", value = result.tag },
   }
 
-  for key, info in pairs(env.variables) do
+  for key, info in pairs(result.env.variables) do
+    ---@diagnostic disable-next-line: unnecessary-if
     if VARS[key] == "ignore" then
       -- skip
     elseif info.type == "exported" then

--- a/hooks/mise_path.lua
+++ b/hooks/mise_path.lua
@@ -1,3 +1,27 @@
-function PLUGIN:MisePath(_)
-  return { }
+local utils = require("utils")
+
+---@type Strings
+local strings = require("vfox.strings")
+
+function PLUGIN:MisePath(ctx)
+  local options = ctx.options
+  if options == false then
+    return {}
+  elseif options == true then
+    options = {}
+  end
+
+  ---@cast options Options
+  local result = utils.load_env(options)
+  if result == nil then
+    return {}
+  end
+
+  for key, info in pairs(result.env.variables) do
+    if key == "PATH" then
+      return strings.split(info.value, ":")
+    end
+  end
+
+  return {}
 end

--- a/test/bar/flake.lock
+++ b/test/bar/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1749213349,
+        "narHash": "sha256-UAaWOyQhdp7nXzsbmLVC67fo+QetzoTm9hsPf9X3yr4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "a4ff0e3c64846abea89662bfbacf037ef4b34207",
         "type": "github"
       },
       "original": {

--- a/test/bar/flake.nix
+++ b/test/bar/flake.nix
@@ -30,9 +30,9 @@
       devShells = eachSystem (pkgs: {
         default = pkgs.mkShell {
           packages = with pkgs; [ yash ];
-          shellHook = ''
-            export FOO=bar
-          '';
+          env = {
+            BAR = "bar";
+          };
         };
       });
     };

--- a/test/foo/flake.lock
+++ b/test/foo/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1749213349,
+        "narHash": "sha256-UAaWOyQhdp7nXzsbmLVC67fo+QetzoTm9hsPf9X3yr4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "a4ff0e3c64846abea89662bfbacf037ef4b34207",
         "type": "github"
       },
       "original": {

--- a/test/foo/flake.nix
+++ b/test/foo/flake.nix
@@ -30,9 +30,9 @@
       devShells = eachSystem (pkgs: {
         default = pkgs.mkShell {
           packages = with pkgs; [ dash ];
-          shellHook = ''
-            export FOO=bar
-          '';
+          env = {
+            FOO = "foo";
+          };
         };
       });
     };

--- a/types.lua
+++ b/types.lua
@@ -14,6 +14,7 @@
 --- Nix plugin options
 ---@class Options
 ---@field flake_lock string? Optional lock file to use
+---@field profile_dir string? Optional profile directory to use
 
 --- Nix plugin context
 ---@class Context
@@ -26,8 +27,13 @@
 
 --- VFox built-in strings library
 ---@class Strings
----@field split fun(x: string, delim: string): string[] Split string by delimiter into array of strings
----@field join fun(x: string[], delim: string): string Join array of strings with delimiter
+---@field contains fun(x: string, substr: string): boolean
+---@field has_prefix fun(x: string, prefix: string): boolean
+---@field has_suffix fun(x: string, suffix: string): boolean
+---@field join fun(x: string[], sep: string): string Join array of strings with delimiter
+---@field split fun(x: string, sep: string): string[] Split string by delimiter into array of strings
+---@field trim fun(x: string, suffix: string): string
+---@field trim_space fun(x: string): string
 
 --- Development environment
 ---@class DevEnv


### PR DESCRIPTION
Packages installed when activating environments are vulnerable to being garbage-collected unless a gc-root is set.
This is achieved in this PR by specifying the `--profile` argument and storing the created profile link in the `.mise-nix` directory.